### PR TITLE
T04 refatorar renderização e colisões com grupos

### DIFF
--- a/src/core/game_manager.py
+++ b/src/core/game_manager.py
@@ -16,7 +16,7 @@ class GameManager:
         self._init_game()
 
     def _init_game(self):
-        world = GameWorld()
+        world = GameWorld(self.tela.get_size())
         screen_width, screen_height = self.tela.get_size()
         player = Player(0, 0)
         w_player, h_player = player.frame_width, player.frame_height

--- a/src/core/game_world.py
+++ b/src/core/game_world.py
@@ -3,7 +3,7 @@ from core.camera_group import CameraGroup
 from abc import ABC, abstractmethod
 from typing import List, Tuple
 from core.game_object import GameObject, StaticObject, DynamicObject
-from core.camera_group import CameraGroup
+from entities.obstacle import Obstacle
 
 class GameScene(ABC):
     @abstractmethod
@@ -21,24 +21,25 @@ class GameScene(ABC):
 class GameWorld(GameScene):
     def __init__(self, screen_size: Tuple[int, int]):
         self.all_sprites = CameraGroup()
+        self.camera_group = self.all_sprites
+        self.screen_size = screen_size
         self.obstacles = pygame.sprite.Group()
         self.dynamic_group = pygame.sprite.Group()
 
 
     def set_target(self, target: GameObject):
         self.target = target
-        try:
-            self.all_sprites.set_target(target)
-        except Exception:
-            pass
+        if not hasattr(self.all_sprites, 'set_target'):
+            raise AttributeError("CameraGroup deve possuir um método 'set_target'.")
+        self.all_sprites.set_target(target)
 
     def add_object(self, obj: GameObject):
 
         if isinstance(obj, DynamicObject):
-            layer = 2 + int(obj.pos.y)
+            layer = 2 + int(round(obj.pos.y))
             self.dynamic_group.add(obj)
         elif isinstance(obj, StaticObject):
-            if obj.__class__.__name__ == "Obstacle":
+            if isinstance(obj, Obstacle):
                 layer = 1
                 self.obstacles.add(obj)
             else:
@@ -58,13 +59,11 @@ class GameWorld(GameScene):
                 obj.update(dt)
 
             if isinstance(obj, DynamicObject):
-                try:
-                    new_layer = 2 + int(round(obj.pos.y))
-                    if new_layer != getattr(obj, "render_layer", None):
+                new_layer = 2 + int(round(obj.pos.y))
+                if new_layer != getattr(obj, "render_layer", None):
+                    if hasattr(self.all_sprites, "change_layer"):
                         self.all_sprites.change_layer(obj, new_layer)
-                        obj.render_layer = new_layer
-                except Exception:
-                    pass
+                    obj.render_layer = new_layer
 
     def handle_events(self, events: List[pygame.event.Event]):
         for obj in self.camera_group.sprites():
@@ -73,10 +72,9 @@ class GameWorld(GameScene):
                     obj.process_event(event)
 
     def draw(self, surface: pygame.Surface):
-
-        try:
+        if hasattr(self.all_sprites, "custom_draw"):
             self.all_sprites.custom_draw(surface)
-        except Exception:
+        else:
             self.all_sprites.draw(surface)
 
     def _iterate_objects(self):

--- a/src/core/game_world.py
+++ b/src/core/game_world.py
@@ -2,6 +2,7 @@ import pygame
 from abc import ABC, abstractmethod
 from typing import List, Tuple
 from core.game_object import GameObject, StaticObject, DynamicObject
+from core.camera_group import CameraGroup
 
 
 class GameScene(ABC):
@@ -20,17 +21,17 @@ class GameScene(ABC):
 
 class GameWorld(GameScene):
     def __init__(self, screen_size: Tuple[int, int]):
-        self.objects = pygame.sprite.LayeredUpdates()
+        self.all_sprites = CameraGroup()
         self.obstacles = pygame.sprite.Group()
         self.dynamic_group = pygame.sprite.Group()
 
-        self.target = None
-        self.screen_size = screen_size
-        self.middle = (screen_size[0] // 2, screen_size[1] // 2)
-        self.offset = pygame.math.Vector2()
 
     def set_target(self, target: GameObject):
         self.target = target
+        try:
+            self.all_sprites.set_target(target)
+        except Exception:
+            pass
 
     def add_object(self, obj: GameObject):
 
@@ -47,10 +48,10 @@ class GameWorld(GameScene):
             layer = getattr(obj, "render_layer", 0)
 
         obj.render_layer = layer
-        self.objects.add(obj, layer=layer)
+        self.all_sprites.add(obj, layer=layer)
 
     def remove_object(self, obj: GameObject):
-        self.objects.remove(obj)
+        self.all_sprites.remove(obj)
 
     def update(self, dt: float):
         for obj in self._iterate_active_objects():
@@ -60,7 +61,7 @@ class GameWorld(GameScene):
                 try:
                     new_layer = 2 + int(round(obj.pos.y))
                     if new_layer != getattr(obj, "render_layer", None):
-                        self.objects.change_layer(obj, new_layer)
+                        self.all_sprites.change_layer(obj, new_layer)
                         obj.render_layer = new_layer
                 except Exception:
                     pass
@@ -71,15 +72,14 @@ class GameWorld(GameScene):
                 obj.process_event(event)
 
     def draw(self, surface: pygame.Surface):
-        if self.target and hasattr(self.target, "rect"):
-            self.offset.x = self.target.rect.centerx - self.middle[0]
-            self.offset.y = self.target.rect.centery - self.middle[1]
 
-        for obj in self.objects:
-            obj.draw(surface, self.offset)
+        try:
+            self.all_sprites.custom_draw(surface)
+        except Exception:
+            self.all_sprites.draw(surface)
 
     def _iterate_objects(self):
-        for obj in self.objects:
+        for obj in self.all_sprites:
             yield obj
 
     def _iterate_active_objects(self):

--- a/src/core/game_world.py
+++ b/src/core/game_world.py
@@ -1,9 +1,7 @@
-import bisect
-
 import pygame
 from abc import ABC, abstractmethod
-from typing import List, Dict, Tuple
-from core.game_object import GameObject
+from typing import List, Tuple
+from core.game_object import GameObject, StaticObject, DynamicObject
 
 
 class GameScene(ABC):
@@ -22,38 +20,50 @@ class GameScene(ABC):
 
 class GameWorld(GameScene):
     def __init__(self, screen_size: Tuple[int, int]):
-        self.objects: Dict[int, List[GameObject]] = {}
+        self.objects = pygame.sprite.LayeredUpdates()
+        self.obstacles = pygame.sprite.Group()
+        self.dynamic_group = pygame.sprite.Group()
 
         self.target = None
         self.screen_size = screen_size
         self.middle = (screen_size[0] // 2, screen_size[1] // 2)
         self.offset = pygame.math.Vector2()
-        self._sorted_layers_keys = []
 
     def set_target(self, target: GameObject):
         self.target = target
 
     def add_object(self, obj: GameObject):
-        layer = obj.render_layer
-        self.objects.setdefault(layer, []).append(obj)
 
-        self.objects[layer].append(obj)
-        if layer not in self._sorted_layers_keys:
-            bisect.insort(self._sorted_layers_keys, layer)
+        if isinstance(obj, DynamicObject):
+            layer = 2 + int(obj.pos.y)
+            self.dynamic_group.add(obj)
+        elif isinstance(obj, StaticObject):
+            if obj.__class__.__name__ == "Obstacle":
+                layer = 1
+                self.obstacles.add(obj)
+            else:
+                layer = 0
+        else:
+            layer = getattr(obj, "render_layer", 0)
+
+        obj.render_layer = layer
+        self.objects.add(obj, layer=layer)
 
     def remove_object(self, obj: GameObject):
-        layer = obj.render_layer
-
-        if obj in self.objects.get(layer, []):
-            self.objects[layer].remove(obj)
-
-            if not self.objects[layer]:
-                del self.objects[layer]
-                self._sorted_layers_keys.remove(layer)
+        self.objects.remove(obj)
 
     def update(self, dt: float):
         for obj in self._iterate_active_objects():
             obj.update(dt)
+
+            if isinstance(obj, DynamicObject):
+                try:
+                    new_layer = 2 + int(round(obj.pos.y))
+                    if new_layer != getattr(obj, "render_layer", None):
+                        self.objects.change_layer(obj, new_layer)
+                        obj.render_layer = new_layer
+                except Exception:
+                    pass
 
     def handle_events(self, events: List[pygame.event.Event]):
         for obj in self._iterate_active_objects():
@@ -65,13 +75,12 @@ class GameWorld(GameScene):
             self.offset.x = self.target.rect.centerx - self.middle[0]
             self.offset.y = self.target.rect.centery - self.middle[1]
 
-        for obj in self._iterate_active_objects():
+        for obj in self.objects:
             obj.draw(surface, self.offset)
 
     def _iterate_objects(self):
-        for layer in self._sorted_layers_keys:
-            for obj in self.objects[layer]:
-                yield obj
+        for obj in self.objects:
+            yield obj
 
     def _iterate_active_objects(self):
         for obj in self._iterate_objects():

--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -20,7 +20,7 @@ SCALE_PLAYER = 1.5
 ASSETS_FOLDER = Path(path.join(path.dirname(__file__), '..', '..', 'assets'))
 DIRECTIONS = ["N", "S", "W", "E", "NW", "NE", "SW", "SE"]
 
-PLAYER_BASE_SPEED = 60
+PLAYER_BASE_SPEED = 250
 PLAYER_KEYS = {
     "UP": pygame.K_w,
     "DOWN": pygame.K_s,


### PR DESCRIPTION
  - **Objetivo:** Otimizar a forma como o `GameWorld` atualiza, desenha as camadas (Z-index) e se prepara para o sistema de colisão.
  - **Especificação POO:**
    - No `GameWorld`, substituir as listas de renderização customizadas pela instância de `pygame.sprite.LayeredUpdates()`.
    - Criar grupos lógicos específicos: `self.obstacles_group = pygame.sprite.Group()`, `self.dynamic_group = pygame.sprite.Group()`.
    - Atribuir o parâmetro `_layer` às sprites dependendo do seu tipo (ex: chão = 0, obstáculos = 1, entidades dinâmicas com Z-index baseado no eixo Y dinamicamente no update).
  - **Critérios de Aceite (DoD):**
    - [ ] O método `draw` do `GameWorld` é simplificado para algo como `self.all_sprites.draw(surface)`.
    - [ ] A posição Y das entidades dinâmicas altera seu Z-index dinamicamente (simulando profundidade 2.5D), atualizando a layer dentro do `LayeredUpdates`.
    - [ ] O sistema permite, no futuro, fácil aplicação de `pygame.sprite.spritecollide()` usando os grupos separados.


close #14 