### PR TITLE
feat: implementado o SoundManager para musica de fundo e efeitos sonoros

### DIFF
--- a/src/core/sound_manager.py
+++ b/src/core/sound_manager.py
@@ -14,11 +14,11 @@ class SoundManager:
     def __new__(cls):
         if cls._instance is None:
             cls._instance = super(SoundManager, cls).__new__(cls)
-            cls._instance._inicialized = False
+            cls._instance._initialized = False
         return cls._instance
 
     def __init__(self):
-        if self._inicialized:
+        if self._initialized:
             return
         pygame.mixer.init()
 
@@ -29,7 +29,7 @@ class SoundManager:
         }
 
         self._sfx_counts: Dict [str, int] = {}
-        self._inicialized = True
+        self._initialized = True
 
     def play_music(self, filename: str, loops: int = -1, fade_ms: int = 1000):
         try:
@@ -38,13 +38,10 @@ class SoundManager:
             pygame.mixer.music.set_volume(self.volumes["music"] * self.volumes["master"])
             pygame.mixer.music.play(loops=loops, fade_ms=fade_ms)
         except Exception as e:
-            raise AssetNotFoundException(f"Musica '{filename}' não foi encontrada no caminho {music_path}.") from e
+            raise AssetNotFoundException(f"Musica '{filename}' não foi encontrada.") from e
         
     def play_sfx(self, filename: str):
         sound = AssetManager.get_sound(filename)
-
-        if not sound:
-            raise AssetNotFoundException(f"Som '{filename}' não foi encontrado no caminho {sound}.")
 
         if filename not in self._sfx_counts:
             self._sfx_counts[filename] = 0
@@ -52,16 +49,17 @@ class SoundManager:
         if self._sfx_counts[filename] < 3:
             sound.set_volume(self.volumes["sfx"] * self.volumes["master"])
             self._sfx_counts[filename] += 1
+        elif self._sfx_counts[filename] >= 3:
+            self._sfx_counts[filename] = 0
         else:
-            sound.set_volume(self.volumes["sfx"] * self.volumes["master"] * 0.5)
+            return
         
         channel = sound.play()
         if channel:
-            channel.set_endevent(pygame.USEREVENT)
+            channel.set_endevent(pygame.event.custom_type())
 
     def stop_music(self, fade_ms: int = 500):
         pygame.mixer.music.fadeout(fade_ms)
-        pygame.mixer.music.stop()
 
     def set_volume(self, category: str, volume: float):
         if category in self.volumes:

--- a/src/core/sound_manager.py
+++ b/src/core/sound_manager.py
@@ -1,21 +1,73 @@
+from ast import Dict
+
 import pygame
 
+from core.asset_manager import AssetManager
 from core.exceptions.asset_not_found_exception import AssetNotFoundException
 from core.settings.settings import ASSETS_FOLDER
+from typing import Dict
 
 class SoundManager:
 
-    @classmethod
-    def play_background_music(cls, path: str, volume: float, loops: int = -1):
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super(SoundManager, cls).__new__(cls)
+            cls._instance._inicialized = False
+        return cls._instance
+
+    def __init__(self):
+        if self._inicialized:
+            return
+        pygame.mixer.init()
+
+        self.volumes: Dict[str, float] = {
+            "master": 1.0,
+            "music": 1.0,
+            "sfx": 0.8
+        }
+
+        self._sfx_counts: Dict [str, int] = {}
+        self._inicialized = True
+
+    def play_music(self, filename: str, loops: int = -1, fade_ms: int = 1000):
         try:
-            music_path = ASSETS_FOLDER / "sounds/music" / path
-            
+            music_path = ASSETS_FOLDER / "sounds" / "music" / filename
             pygame.mixer.music.load(str(music_path))
-            pygame.mixer.music.set_volume(volume)
-            pygame.mixer.music.play(loops=loops)
-        except (pygame.error, FileNotFoundError) as e:
-            raise AssetNotFoundException(path, message=f"Erro ao carregar música: {e}")
+            pygame.mixer.music.set_volume(self.volumes["music"] * self.volumes["master"])
+            pygame.mixer.music.play(loops=loops, fade_ms=fade_ms)
+        except Exception as e:
+            raise AssetNotFoundException(f"Musica '{filename}' não foi encontrada no caminho {music_path}.") from e
         
-    @classmethod
-    def stop_background_music(cls):
+    def play_sfx(self, filename: str):
+        sound = AssetManager.get_sound(filename)
+
+        if not sound:
+            raise AssetNotFoundException(f"Som '{filename}' não foi encontrado no caminho {sound}.")
+
+        if filename not in self._sfx_counts:
+            self._sfx_counts[filename] = 0
+        
+        if self._sfx_counts[filename] < 3:
+            sound.set_volume(self.volumes["sfx"] * self.volumes["master"])
+            self._sfx_counts[filename] += 1
+        else:
+            sound.set_volume(self.volumes["sfx"] * self.volumes["master"] * 0.5)
+        
+        channel = sound.play()
+        if channel:
+            channel.set_endevent(pygame.USEREVENT)
+
+    def stop_music(self, fade_ms: int = 500):
+        pygame.mixer.music.fadeout(fade_ms)
         pygame.mixer.music.stop()
+
+    def set_volume(self, category: str, volume: float):
+        if category in self.volumes:
+            self.volumes[category] = max(0.0, min(1.0, volume))
+            if category in ["music", "master"]:
+                pygame.mixer.music.set_volume(self.volumes["music"] * self.volumes["master"])
+        else:
+            raise ValueError(f"Categoria de volume '{category}' não é válida.")
+        

--- a/src/core/states/play_state.py
+++ b/src/core/states/play_state.py
@@ -33,7 +33,7 @@ class PlayState(BaseState):
         if (self.initialized):
             return
         try:
-            SoundManager.play_background_music("Crashsite-Defense.wav", volume=0.7)
+            SoundManager().play_music("Crashsite-Defense.wav")
         except Exception as e:
             logging.error(f"{e}")
         

--- a/src/entities/character/player.py
+++ b/src/entities/character/player.py
@@ -6,6 +6,7 @@ from core.enums.projectile.projectile_types_enum import ProjectileTypesEnum
 from core.enums.projectile.projectile_variant_enum import ProjectileVariantEnum
 from core.event_manager import EventManager
 from core.settings.settings import ASSETS_FOLDER, PLAYER_KEYS, SCALE_PLAYER, PLAYER_BASE_SPEED
+from core.sound_manager import SoundManager
 from entities.character.characters import Character
 from utils.image import load_image
 
@@ -135,7 +136,7 @@ class Player(Character):
             )
 
             try:
-                self._shot_sound.play()
+                SoundManager().play_sfx("effects/shoot.wav")
             except Exception as e:
                 print(f"Error playing shoot sound: {e}")
 


### PR DESCRIPTION
- **Objetivo:** Controlar a reprodução nativa utilizando as APIs do Pygame-CE (`pygame.mixer.Sound` para SFX e `pygame.mixer.music` para trilhas contínuas).
- **Especificação POO:**
  - Criar classe `AudioManager` (Singleton).
  - No `__init__`, garantir a inicialização com `pygame.mixer.init()`. Configurar categorias de volume: `self.volumes = {"master": 1.0, "music": 0.8, "sfx": 1.0}`.
  - Implementar `play_music(filename, loops=-1, fade_ms=1000)` usando `pygame.mixer.music.load` e `pygame.mixer.music.play`.
  - Implementar `play_sfx(sound_name)` que busca o som no `AssetManager` e utiliza `sound.play()`.
  - *Limite de 3 áudios de mesmo tipo simultâneos:* Adicionar um controle de limite de sons simultâneos no `play_sfx` (ex: não tocar mais que 3 sons idênticos no mesmo frame) para evitar estouro de áudio (audio clipping).
- **Critérios de Aceite (DoD):**
  - [ ] Músicas de fundo tocam em loop contínuo e podem sofrer *fade out* na troca de *states* (ex: de Menu para Gameplay).
  - [ ] SFXs podem ser tocados simultaneamente sem interromper a música de fundo.
  - [ ] Alterar o volume de `sfx` ajusta o volume de todos os efeitos tocados a partir daquele momento.

closes #31 