### PR TITLE
45 criar entitysprite e refatorar base gameobject

### DIFF
--- a/src/core/entity_sprite.py
+++ b/src/core/entity_sprite.py
@@ -1,19 +1,17 @@
 import pygame
-
 class EntitySprite(pygame.sprite.Sprite):
     def __init__(self, owner, *groups: pygame.sprite.Group):
         super().__init__(*groups)
         self.owner = owner
 
     def update(self, dt: float):
-        if hasattr(self.owner, 'active') and not self.owner.active:
+        if not self.owner.active:
             return
-        if hasattr(self.owner, 'update'):
-            return self.owner.update(dt)
+        self.owner.update(dt)
         
     def process_event(self, event: pygame.event.Event):
-        if hasattr(self.owner, 'process_event'):
-            return self.owner.process_event(event)
+        self.owner.process_event(event)
         
     def __getattr__(self, name):
         return getattr(self.owner, name)
+        

--- a/src/core/entity_sprite.py
+++ b/src/core/entity_sprite.py
@@ -1,0 +1,19 @@
+import pygame
+
+class EntitySprite(pygame.sprite.Sprite):
+    def __init__(self, owner, *groups: pygame.sprite.Group):
+        super().__init__(*groups)
+        self.owner = owner
+
+    def update(self, dt: float):
+        if hasattr(self.owner, 'active') and not self.owner.active:
+            return
+        if hasattr(self.owner, 'update'):
+            return self.owner.update(dt)
+        
+    def process_event(self, event: pygame.event.Event):
+        if hasattr(self.owner, 'process_event'):
+            return self.owner.process_event(event)
+        
+    def __getattr__(self, name):
+        return getattr(self.owner, name)

--- a/src/core/game_object.py
+++ b/src/core/game_object.py
@@ -2,16 +2,34 @@ from abc import ABC, abstractmethod
 import pygame
 from pygame.math import Vector2
 
+from core.entity_sprite import EntitySprite
 
-class GameObject(ABC, pygame.sprite.Sprite):
+
+class GameObject(ABC):
     render_layer: int = 0
 
     def __init__(self, x: float, y: float, *groups: pygame.sprite.Group):
-        super().__init__(*groups)
+        self._sprite = EntitySprite(self, *groups)
         self.pos = Vector2(x, y)
         self.active = True
         self.image = None
         self.rect = None
+
+    @property
+    def image(self):
+        return self._sprite.image
+    
+    @image.setter
+    def image(self, value):
+        self._sprite.image = value
+
+    @property
+    def rect(self):
+        return self._sprite.rect
+    
+    @rect.setter
+    def rect(self, value):
+        self._sprite.rect = value
 
     @abstractmethod
     def update(self, dt: float):
@@ -21,6 +39,15 @@ class GameObject(ABC, pygame.sprite.Sprite):
     def process_event(self, event: pygame.event.Event):
         """Processamento de eventos específicos (override se necessário)."""
         pass
+
+    def kill(self):
+        """Desativa o objeto e remove seu sprite do grupo."""
+        self.active = False
+        self._sprite.kill()
+
+    def alive(self):
+        """Verifica se o objeto ainda está ativo."""
+        return self._sprite.alive()
 
 
 class StaticObject(GameObject):

--- a/src/core/game_world.py
+++ b/src/core/game_world.py
@@ -45,23 +45,23 @@ class GameWorld(GameScene):
         if not hasattr(self.all_sprites, 'set_target'):
             raise AttributeError("CameraGroup deve possuir um método 'set_target'.")
         self.all_sprites.set_target(target)
-        self.player_group.add(target)
+        self.player_group.add(target._sprite)
 
     def add_object(self, obj: GameObject):
 
         layer = 0
         if isinstance(obj, Projectile):
             if obj.friendly:
-                self.friend_projectiles_group.add(obj)
+                self.friend_projectiles_group.add(obj._sprite)
             else:
-                self.enemy_projectiles_group.add(obj)
+                self.enemy_projectiles_group.add(obj._sprite)
         
         if isinstance(obj, DynamicObject):
             layer = 2 + int(round(obj.pos.y))
-            self.dynamic_group.add(obj)
+            self.dynamic_group.add(obj._sprite)
 
             if isinstance(obj, Enemy):
-                self.enemies_group.add(obj)
+                self.enemies_group.add(obj._sprite)
                 
         elif isinstance(obj, EnemySpawner):
             if obj.spawner_id in self.spawners:
@@ -73,17 +73,17 @@ class GameWorld(GameScene):
         elif isinstance(obj, StaticObject):
             if isinstance(obj, Obstacle):
                 layer = 1
-                self.obstacles.add(obj)
+                self.obstacles.add(obj._sprite)
             else:
                 layer = 0
         else:
             layer = getattr(obj, "render_layer", 0)
 
         obj.render_layer = layer
-        self.all_sprites.add(obj, layer=layer)
+        self.all_sprites.add(obj._sprite, layer=layer)
 
     def remove_object(self, obj: GameObject):
-        self.all_sprites.remove(obj)
+        self.all_sprites.remove(obj._sprite)
 
     def update(self, dt: float):
         for obj in self.camera_group.sprites():

--- a/src/core/game_world.py
+++ b/src/core/game_world.py
@@ -86,8 +86,9 @@ class GameWorld(GameScene):
         self.all_sprites.remove(obj._sprite)
 
     def update(self, dt: float):
-        for obj in self.camera_group.sprites():
-            if obj.active:
+        for sprite in self.camera_group.sprites():
+            obj = sprite.owner
+            if obj.active and hasattr(obj, "update"):
                 obj.update(dt)
         
             if not obj.alive():

--- a/src/entities/character/characters.py
+++ b/src/entities/character/characters.py
@@ -30,6 +30,5 @@ class Character(DynamicObject):
         super().update(dt)
 
     def on_death(self):
-        EventManager.get_instance().emit(GameEventEnum.PLAY_SFX, "effects/death.mp3")
         self.active = False
         self.kill()

--- a/src/entities/character/player.py
+++ b/src/entities/character/player.py
@@ -108,7 +108,7 @@ class Player(Character):
         if self.rect is not None:
             # Obtém o deslocamento da câmera para converter a posição da tela para posição do mundo
             camera_offset = pygame.math.Vector2(0, 0)
-            for group in self.groups():
+            for group in self._sprite.groups():
                 if hasattr(group, 'offset'):
                     camera_offset = group.offset
                     break


### PR DESCRIPTION
  - **Objetivo:** Criar o componente visual e delegar as responsabilidades de ciclo de vida e estado (image/rect) para ele.
  - **Especificação POO:**
    - Criar a classe `EntitySprite(pygame.sprite.Sprite)`. O construtor recebe `owner` (o `GameObject` pai) e `*groups`. Internamente faz `self.owner = owner`.
    - Em `GameObject`, remover a herança de `pygame.sprite.Sprite`.
    - No `GameObject.__init__`, instanciar `self._sprite = EntitySprite(self, *groups)`.
    - Implementar properties em `GameObject` para sincronização elegante:
      - `@property def image(self): return self._sprite.image`
      - `@image.setter def image(self, val): self._sprite.image = val`
      - Fazer o mesmo para `rect`.
    - Delegar métodos de ciclo de vida: Criar `def kill(self): self._sprite.kill()` e `def alive(self): return self._sprite.alive()`.
  - **Critérios de Aceite (DoD):**
    - [ ] `GameObject` não possui mais referências a `super().__init__(*groups)` em contexto de Sprite.
    - [ ] Chamar `game_object.kill()` remove o `_sprite` interno de todos os grupos do Pygame com sucesso.


Closes #45 