### PR TITLE
refactor: Atualização no tratamento de camera_group para melhorar o g…

### DIFF
--- a/src/core/camera_group.py
+++ b/src/core/camera_group.py
@@ -19,7 +19,7 @@ class CameraGroup(pygame.sprite.LayeredUpdates):
             self.offset.y = self.target.rect.centery - self.half_h
 
         for sprite in self.sprites():
-            if getattr(sprite, 'active', True):
+            if sprite.owner.active:
                 offset_pos = sprite.rect.topleft - self.offset
                 surface.blit(sprite.image, offset_pos)
                 

--- a/src/core/camera_group.py
+++ b/src/core/camera_group.py
@@ -19,7 +19,8 @@ class CameraGroup(pygame.sprite.LayeredUpdates):
             self.offset.y = self.target.rect.centery - self.half_h
 
         for sprite in self.sprites():
-            if sprite.owner.active:
+            owner = getattr(sprite, 'owner', None)
+            if owner is None or getattr(owner, 'active', True):
                 offset_pos = sprite.rect.topleft - self.offset
                 surface.blit(sprite.image, offset_pos)
                 

--- a/src/core/game_world.py
+++ b/src/core/game_world.py
@@ -97,6 +97,17 @@ class GameWorld(GameScene):
         self._resolve_player_obstacle_collisions()
         self._resolve_player_enemy_collisions()
 
+        for sprite in self.camera_group.sprites():
+            obj = sprite.owner
+            if obj.active and isinstance(obj, DynamicObject):
+                new_layer = 2 + int(round(obj.pos.y))
+                if new_layer != getattr(obj, "render_layer", None):
+                    if hasattr(self.all_sprites, "change_layer"):
+                        self.camera_group.change_layer(sprite, new_layer)
+                    elif hasattr(self.all_sprites, "change_layer"):
+                        self.all_sprites.change_layer(sprite, new_layer)
+                    obj.render_layer = new_layer
+
         for obj in self.camera_group.sprites():
             if obj.active and isinstance(obj, DynamicObject):
                 new_layer = 2 + int(round(obj.pos.y))

--- a/src/core/game_world.py
+++ b/src/core/game_world.py
@@ -108,14 +108,6 @@ class GameWorld(GameScene):
                         self.all_sprites.change_layer(sprite, new_layer)
                     obj.render_layer = new_layer
 
-        for obj in self.camera_group.sprites():
-            if obj.active and isinstance(obj, DynamicObject):
-                new_layer = 2 + int(round(obj.pos.y))
-                if new_layer != getattr(obj, "render_layer", None):
-                    if hasattr(self.all_sprites, "change_layer"):
-                        self.all_sprites.change_layer(obj, new_layer)
-                    obj.render_layer = new_layer
-
         hits = pygame.sprite.groupcollide(self.enemies_group, self.friend_projectiles_group, False, True)
         for enemy, shots in hits.items():
             for shot in shots:


### PR DESCRIPTION
  - **Objetivo:** Adequar a iteração do sistema de câmera para tratar sprites em vez de GameObjects lógicos.
  - **Especificação POO:**
    - No `game_world.py` e `camera_group.py`, atualizar as lógicas que dependem dos objetos no grupo.
    - Onde houver `for obj in self.camera_group.sprites():`, adaptar o uso sabendo que `obj` é agora o `EntitySprite`.
    - Se a lógica da câmera precisar da posição exata ou layer lógico, ela deve ler `obj.rect` (para visual) ou `obj.owner` (caso precise verificar qual é a classe original para Y-Sorting ou mudança de layers lógicas).
  - **Critérios de Aceite (DoD):**
    - [ ] A tela volta a ser renderizada sem *crashes*.
    - [ ] A ordenação de Z-index (Y-Sorting) funciona normalmente lendo os dados atrelados aos sprites.
    
closes #46 