### PR TITLE
feat: implementado knockback no player quando atingido por um inimigo

### DIFF
--- a/src/core/game_manager.py
+++ b/src/core/game_manager.py
@@ -71,6 +71,10 @@ class GameManager:
                         f"FPS: {self.clock.get_fps():.0f}", True, (0, 255, 0))
                     self.tela.blit(txt_fps, (10, 60))
 
+                    txt_life = self.debug_font.render(
+                        f"Vida: {player.health.current_hp:.0f}/{player.health.max_hp:.0f}", True, (255, 0, 0))
+                    self.tela.blit(txt_life, (10, 85))
+
         pygame.display.flip()
 
     def on_cleanup(self):

--- a/src/core/game_object.py
+++ b/src/core/game_object.py
@@ -63,9 +63,15 @@ class DynamicObject(GameObject):
         super().__init__(initial_position, *groups)
         self.velocity = Vector2(0, 0)
         self.acceleration = Vector2(0, 0)
+        self.friction = 0.85
 
     def update(self, dt: float):
         self.velocity += self.acceleration * dt
+        self.velocity *= self.friction
+
+        if self.velocity.length() < 0.01:
+            self.velocity = Vector2(0, 0)
+
         self.pos += self.velocity * dt
         if self.rect:
             self.rect.topleft = (round(self.pos.x), round(self.pos.y))

--- a/src/core/game_world.py
+++ b/src/core/game_world.py
@@ -192,49 +192,18 @@ class GameWorld(GameScene):
             e_rect = e_owner.hitbox if hasattr(e_owner, "hitbox") else e_owner.rect
             return p_rect.colliderect(e_rect)
 
-        touching_enemies = pygame.sprite.spritecollide(player_sprite, self.enemies_group, False, collided=collide_hitbox)
-        
+        touching_enemies = pygame.sprite.spritecollide(
+            player_sprite, self.enemies_group, False, collided=collide_hitbox
+        )
+
         for enemy_sprite in touching_enemies:
-            if isinstance(player, Player):
-                player.health.take_damage(10.0)
-                try:
-                    EventManager.get_instance().emit(GameEventEnum.PLAY_SFX, filename="effects/damage.mp3")
-                except Exception as e:
-                    print(f"Erro ao reproduzir som de hit: {e}")
-                
-                p_rect = player.hitbox if hasattr(player, "hitbox") else player.rect
-                e_rect = enemy_sprite.owner.hitbox if hasattr(enemy_sprite.owner, "hitbox") else enemy_sprite.owner.rect
-
-                dx = p_rect.centerx - e_rect.centerx
-                dy = p_rect.centery - e_rect.centery
-
-                distance = math.hypot(dx, dy)
-                if distance > 0:
-                    dx /= distance
-                    dy /= distance
-                else:
-                    dx, dy = 0, -1 
-
-                knockback_strength = 30.0 
-                kx = dx * knockback_strength
-                ky = dy * knockback_strength
-
-                if hasattr(player, "prev_pos"):
-                    player.pos.x = player.prev_pos.x + kx
-                    player.pos.y = player.prev_pos.y + ky
-                else:
-                    player.pos.x += kx
-                    player.pos.y += ky
-
-                if hasattr(player, "hitbox"):
-                    player.hitbox.center = (round(player.pos.x), round(player.pos.y))
-                if hasattr(player, "feet_hitbox"):
-                    player.feet_hitbox.midbottom = player.hitbox.midbottom
-                player_sprite.rect.center = (round(player.pos.x), round(player.pos.y))
-
-
-                if hasattr(player, "set_invulnerable"):
-                    player.set_invulnerable(duration_frames=30) 
-                else:
-                    player.is_invulnerable = True
-                    player.invulnerable_timer = 30
+            
+            enemy = enemy_sprite.owner
+            
+            player.health.take_damage(10.0)
+            player.apply_knockback(enemy.pos, force=1500.0)  
+            
+            try:
+                EventManager.get_instance().emit(GameEventEnum.PLAY_SFX, filename="effects/damage.mp3")
+            except Exception as e:
+                print(f"Erro ao reproduzir som de hit: {e}")

--- a/src/core/game_world.py
+++ b/src/core/game_world.py
@@ -10,6 +10,7 @@ from entities.obstacle import Obstacle
 from entities.projectiles.projectile import Projectile
 from entities.character.player import Player
 from entities.enemy_spawner import EnemySpawner
+import math
 
 
 
@@ -192,6 +193,7 @@ class GameWorld(GameScene):
             return p_rect.colliderect(e_rect)
 
         touching_enemies = pygame.sprite.spritecollide(player_sprite, self.enemies_group, False, collided=collide_hitbox)
+        
         for enemy_sprite in touching_enemies:
             if isinstance(player, Player):
                 player.health.take_damage(10.0)
@@ -199,12 +201,40 @@ class GameWorld(GameScene):
                     EventManager.get_instance().emit(GameEventEnum.PLAY_SFX, filename="effects/damage.mp3")
                 except Exception as e:
                     print(f"Erro ao reproduzir som de hit: {e}")
-            
+                
+                p_rect = player.hitbox if hasattr(player, "hitbox") else player.rect
+                e_rect = enemy_sprite.owner.hitbox if hasattr(enemy_sprite.owner, "hitbox") else enemy_sprite.owner.rect
+
+                dx = p_rect.centerx - e_rect.centerx
+                dy = p_rect.centery - e_rect.centery
+
+                distance = math.hypot(dx, dy)
+                if distance > 0:
+                    dx /= distance
+                    dy /= distance
+                else:
+                    dx, dy = 0, -1 
+
+                knockback_strength = 30.0 
+                kx = dx * knockback_strength
+                ky = dy * knockback_strength
+
                 if hasattr(player, "prev_pos"):
-                    player.pos.x = player.prev_pos.x
-                    player.pos.y = player.prev_pos.y
-                    if hasattr(player, "hitbox"):
-                        player.hitbox.center = (round(player.pos.x), round(player.pos.y))
-                    if hasattr(player, "feet_hitbox"):
-                        player.feet_hitbox.midbottom = player.hitbox.midbottom
-                    player_sprite.rect.center = (round(player.pos.x), round(player.pos.y))
+                    player.pos.x = player.prev_pos.x + kx
+                    player.pos.y = player.prev_pos.y + ky
+                else:
+                    player.pos.x += kx
+                    player.pos.y += ky
+
+                if hasattr(player, "hitbox"):
+                    player.hitbox.center = (round(player.pos.x), round(player.pos.y))
+                if hasattr(player, "feet_hitbox"):
+                    player.feet_hitbox.midbottom = player.hitbox.midbottom
+                player_sprite.rect.center = (round(player.pos.x), round(player.pos.y))
+
+
+                if hasattr(player, "set_invulnerable"):
+                    player.set_invulnerable(duration_frames=30) 
+                else:
+                    player.is_invulnerable = True
+                    player.invulnerable_timer = 30

--- a/src/entities/character/characters.py
+++ b/src/entities/character/characters.py
@@ -13,12 +13,43 @@ class Character(DynamicObject):
         self.health = HealthComponent(max_hp=100.0, on_death_callback=self.on_death, iframes_duration=0.5)
         self.speed = speed
         self.direction = pygame.math.Vector2(0, 0)
+        self.is_knockedback = False
+        self.knockback_timer = 0.0
 
     def move(self, dt: float):
+        if self.is_knockedback:
+            self.pos += self.velocity * dt
+            self.velocity *= self.friction
+            self.knockback_timer = 0
+            if self.knockback_timer <= 0:
+                self.is_knockedback = False
+                self.velocity = pygame.math.Vector2(0, 0)
+            return
+
         if self.direction.length() > 0:
             self.direction = self.direction.normalize()
 
-        self.velocity = self.direction * self.speed
+        input_velocity = self.direction * self.speed
+
+        self.velocity = input_velocity + getattr(self, 'knockback_velocity', pygame.math.Vector2(0, 0))
+
+    def apply_knockback(self, source_pos: pygame.math.Vector2, force: float):
+        print(f"Applying knockback from {source_pos} with force {force}")
+        direction = self.pos - source_pos
+        if direction.length_squared() > 0:
+            direction = direction.normalize()
+        else: 
+            direction = pygame.math.Vector2(0, -1)
+        self.velocity += direction * force
+
+        self.is_knockedback = True
+        self.knockback_timer = 0.0
+
+    
+    def apply_knockback_from_direction(self, direction: pygame.math.Vector2, force: float):        
+        if direction.length_squared() > 0:
+            direction = direction.normalize()
+            self.velocity += direction * force
 
     def update(self, dt: float):
         if not self.active:

--- a/src/entities/character/player.py
+++ b/src/entities/character/player.py
@@ -34,6 +34,7 @@ class Player(Character):
 
         return on_death
     
+    
     @property
     def frame_width(self) -> int:
         return self.image.get_width() if self.image else 0
@@ -106,7 +107,6 @@ class Player(Character):
         mouse_pos = pygame.math.Vector2(pygame.mouse.get_pos())
         
         if self.rect is not None:
-            # Obtém o deslocamento da câmera para converter a posição da tela para posição do mundo
             camera_offset = pygame.math.Vector2(0, 0)
             for group in self._sprite.groups():
                 if hasattr(group, 'offset'):
@@ -120,7 +120,7 @@ class Player(Character):
             if direction.length() > 0:
                 direction = direction.normalize()
             else:
-                direction = pygame.math.Vector2(0, 1) # Fallback caso mouse_pos == start_pos
+                direction = pygame.math.Vector2(0, 1)
 
             EventManager.get_instance().emit(
                 GameEventEnum.SPAWN_PROJECTILE,
@@ -136,7 +136,8 @@ class Player(Character):
 
 
     def update(self, dt: float):
-        self.handle_input()
+        if not self.is_knockedback:
+            self.handle_input() 
         self._shot_timer += dt
 
         self.prev_pos = self.pos.copy()
@@ -150,11 +151,13 @@ class Player(Character):
         self.hitbox.center = (round(self.pos.x), round(self.pos.y))
         self.feet_hitbox.midbottom = self.hitbox.midbottom
 
-        state = "idle"
-        if self.direction.x != 0 or self.direction.y != 0:
-            state = "running" if self._is_running else "walking"
+        if not self.is_knockedback:
 
-        self.animator.play(f"{state}_{self._last_direction.text}")
+            state = "idle"
+            if self.direction.x != 0 or self.direction.y != 0:
+                state = "running" if self._is_running else "walking"
+
+            self.animator.play(f"{state}_{self._last_direction.text}")
         
         if self.rect is not None:
             self.rect.center = self.hitbox.center


### PR DESCRIPTION
- **Objetivo:** Implementar um sistema de reação física (knockback) quando entidades sofrem dano, garantindo feedback visual imediato e separação lógica entre a aplicação de dano e a força de impacto.
- **Especificação POO:**
  - Adicionar um método `apply_knockback(source_pos: Vector2, force: float)` na classe base `Character` (ou `DynamicObject`).
  - O método deve calcular o vetor de direção normalizado (`self.pos - source_pos`) e somar um impulso instantâneo à propriedade `self.velocity` herdada.
  - Implementar um sistema de "atrito" (friction) no método `update()` do `DynamicObject` para que a velocidade decaia naturalmente, evitando que o objeto deslize infinitamente pelo mapa após o impacto.
  - Integrar a chamada de `apply_knockback` nos métodos de resolução de colisão do `GameWorld` (ex: `_resolve_player_enemy_collisions` e validações de acerto de projéteis).
- **Atualização na Herança Base (`GameObject` / `DynamicObject`):**
  - Modificar o método `update(dt)` da classe `DynamicObject` para aplicar um multiplicador de atrito (`self.velocity *= friction_factor`) a cada frame antes de atualizar a posição final.
  - Garantir que classes filhas que sobrescrevem o movimento (como o `Player` via input de teclado) tratem a `velocity` de forma cumulativa, somando a aceleração do input ao impulso residual do knockback, sem sobrescrever o vetor abruptamente.
- **Critérios de Aceite (DoD):**
  - [ ] Quando o `Player` recebe dano de contato de um `Enemy`, ele é empurrado visualmente para a direção oposta à posição do inimigo.
  - [ ] O impulso decai gradualmente graças ao atrito implementado no `DynamicObject`, fazendo a entidade parar de deslizar de forma natural.
  - [ ] O sistema suporta knockback direcional causado por projéteis (onde a direção do impacto é baseada no vetor `direction` do projétil, e não na sua posição de origem).
  - [ ] A aplicação do knockback é bloqueada quando a entidade está em estado de invulnerabilidade (`iframes` do `HealthComponent`), evitando empurrões múltiplos ou infinitos em casos de sobreposição de hitboxes no mesmo frame.
  
  closes #56  