### PR TITLE
feat: integrar EnemyFactory ao EnemySpawner para a geração de inimigos

### DIFF
--- a/src/entities/enemy_factory.py
+++ b/src/entities/enemy_factory.py
@@ -1,0 +1,17 @@
+from entities.character.goblin import Goblin
+
+
+class EnemyFactory:
+
+    _registry = {  # noqa: RUF012
+        "goblin": Goblin,
+    }
+
+    @classmethod
+    def create_enemy(self,enemy_type: str, x: float, y: float, path: list):
+        enemy_class = EnemyFactory._registry.get(enemy_type)
+
+        if enemy_class is None:
+            raise ValueError(f"Inimigo desconhecido: {enemy_type}")
+
+        return enemy_class(x, y, path=path)

--- a/src/entities/enemy_spawner.py
+++ b/src/entities/enemy_spawner.py
@@ -5,8 +5,7 @@ from core.enums.game_event_enum import GameEventEnum
 from core.event_manager import EventManager
 from core.game_object import StaticObject
 from core.map.waypoints.polyline import Polyline
-from entities.character.goblin import Goblin
-from entities.enemy import Enemy
+from entities.enemy_factory import EnemyFactory
 
 
 class EnemySpawner(StaticObject):
@@ -29,6 +28,6 @@ class EnemySpawner(StaticObject):
             self.spawn_enemy()
             self.spawn_timer = 0.0
 
-    def spawn_enemy(self, enemy_type: str = "default"):
-        new_enemy = Goblin(self.pos.x, self.pos.y, path=self.path)
+    def spawn_enemy(self, enemy_type: str = "goblin"):
+        new_enemy = EnemyFactory.create_enemy(enemy_type, self.pos.x, self.pos.y, self.path)
         EventManager.get_instance().emit(GameEventEnum.ENEMY_SPAWNED, new_enemy)


### PR DESCRIPTION
 - **Objetivo:** Tornar o Goblin instanciável através do sistema centralizado de controle de hordas.
  - **Especificação POO:**
    - Ir na factory de inimigos (ex: `EnemyFactory` ou o método `spawn_enemy` do `EnemySpawner` da nossa Sprint anterior).
    - Adicionar a string identificadora `"goblin"` ao dicionário/match-case que decide qual classe instanciar.
    - Garantir que o Spawner passe o `path` (Waypoints) e a posição inicial corretamente para o construtor do Goblin.
  - **Critérios de Aceite (DoD):**
    - [x] Quando o `WaveManager` disparar a ordem para criar um `"goblin"`, o modelo correto é instanciado na tela, persegue o caminho e usa suas 4 animações.

closes #68 